### PR TITLE
Allow PUT with CORS

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -30,6 +30,7 @@ func plasticApi() *iris.Application {
 
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   ["GET", "PUT", "POST"],
 		AllowCredentials: true,
 		// Enable Debugging for testing, consider disabling in production
 		Debug: true,


### PR DESCRIPTION
@tingold For updating the StreetView imagery in the near-term, it'll be super useful to be able to PUT to this API with CORS. I think this is what's called for - just following the docs at https://github.com/rs/cors#parameters. LMK if anything needs to be different here.