### PR TITLE
Fix site_id parameter in delete sites route

### DIFF
--- a/api/handler/site.go
+++ b/api/handler/site.go
@@ -118,7 +118,7 @@ func (sh *SiteHandler) DeleteAllSites(ctx iris.Context) {
 func (sh *SiteHandler) DeleteSiteById(ctx iris.Context) {
 
 	s := model.Site{}
-	id, err := ctx.URLParamInt64("site_id")
+	id, err := ctx.Params().GetInt64("site_id")
 	if err != nil {
 		ctx.Problem(iris.NewProblem().Status(400).Detail("Invalid Site ID"))
 		return


### PR DESCRIPTION
Fixes #43 - grabs the `{site_id}` parameter from a URL segment rather than a query parameter.

Note - please test, I don't have a fully set-up Go environment 🙈 